### PR TITLE
only submit previous files in output only problem when the task mode is SCORE_MODE_MAX_TOKENED_LAST

### DIFF
--- a/cms/server/contest/submission/workflow.py
+++ b/cms/server/contest/submission/workflow.py
@@ -31,6 +31,7 @@ import logging
 
 from cms import config
 from cms.db import Submission, File, UserTestManager, UserTestFile, UserTest
+from cmscommon.constants import SCORE_MODE_MAX_TOKENED_LAST
 from cmscommon.datetime import make_timestamp
 from .check import check_max_number, check_min_interval
 from .file_matching import InvalidFilesOrLanguage, match_files_and_language
@@ -150,9 +151,10 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
     missing_codenames = required_codenames.difference(files.keys())
     if len(missing_codenames) > 0:
         if task.active_dataset.task_type_object.ALLOW_PARTIAL_SUBMISSION:
-            digests = fetch_file_digests_from_previous_submission(
-                sql_session, participation, task, language,
-                missing_codenames)
+            if task.score_mode == SCORE_MODE_MAX_TOKENED_LAST:
+                digests = fetch_file_digests_from_previous_submission(
+                    sql_session, participation, task, language,
+                    missing_codenames)
         else:
             raise UnacceptableSubmission(
                 N_("Invalid submission format!"),

--- a/cmstestsuite/unit_tests/grading/tasktypes/OutputOnlyTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/OutputOnlyTest.py
@@ -29,8 +29,8 @@ from cmstestsuite.unit_tests.grading.tasktypes.tasktypetestutils import \
     OUTCOME, TEXT, TaskTypeTestMixin
 
 
-FILE_001 = File(digest="digest of 001", filename="output_001.txt")
-FILE_023 = File(digest="digest of 023", filename="output_023.txt")
+FILE_001 = File(digest="digest of 001", filename="001.out")
+FILE_023 = File(digest="digest of 023", filename="023.out")
 
 
 class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
@@ -69,8 +69,8 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_diff_success(self):
         tt, job = self.prepare(["diff"], {
-            "output_001.txt": FILE_001,
-            "output_023.txt": FILE_023
+            "001.out": FILE_001,
+            "023.out": FILE_023
         })
 
         tt.evaluate(job, self.file_cacher)
@@ -81,7 +81,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_diff_missing_file(self):
         tt, job = self.prepare(["diff"], {
-            "output_001.txt": FILE_001,
+            "001.out": FILE_001,
         })
 
         tt.evaluate(job, self.file_cacher)
@@ -92,8 +92,8 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_diff_failure(self):
         tt, job = self.prepare(["diff"], {
-            "output_001.txt": FILE_001,
-            "output_023.txt": FILE_023
+            "001.out": FILE_001,
+            "023.out": FILE_023
         })
         self.eval_output.return_value = False, None, None
 
@@ -105,8 +105,8 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_comparator_success(self):
         tt, job = self.prepare(["comparator"], {
-            "output_001.txt": FILE_001,
-            "output_023.txt": FILE_023
+            "001.out": FILE_001,
+            "023.out": FILE_023
         })
 
         tt.evaluate(job, self.file_cacher)

--- a/cmstestsuite/unit_tests/grading/tasktypes/OutputOnlyTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/OutputOnlyTest.py
@@ -29,8 +29,8 @@ from cmstestsuite.unit_tests.grading.tasktypes.tasktypetestutils import \
     OUTCOME, TEXT, TaskTypeTestMixin
 
 
-FILE_001 = File(digest="digest of 001", filename="001.out")
-FILE_023 = File(digest="digest of 023", filename="023.out")
+FILE_001 = File(digest="digest of 001", filename="output_001.txt")
+FILE_023 = File(digest="digest of 023", filename="output_023.txt")
 
 
 class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
@@ -69,8 +69,8 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_diff_success(self):
         tt, job = self.prepare(["diff"], {
-            "001.out": FILE_001,
-            "023.out": FILE_023
+            "output_001.txt": FILE_001,
+            "output_023.txt": FILE_023
         })
 
         tt.evaluate(job, self.file_cacher)
@@ -81,7 +81,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_diff_missing_file(self):
         tt, job = self.prepare(["diff"], {
-            "001.out": FILE_001,
+            "output_001.txt": FILE_001,
         })
 
         tt.evaluate(job, self.file_cacher)
@@ -92,8 +92,8 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_diff_failure(self):
         tt, job = self.prepare(["diff"], {
-            "001.out": FILE_001,
-            "023.out": FILE_023
+            "output_001.txt": FILE_001,
+            "output_023.txt": FILE_023
         })
         self.eval_output.return_value = False, None, None
 
@@ -105,8 +105,8 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
 
     def test_comparator_success(self):
         tt, job = self.prepare(["comparator"], {
-            "001.out": FILE_001,
-            "023.out": FILE_023
+            "output_001.txt": FILE_001,
+            "output_023.txt": FILE_023
         })
 
         tt.evaluate(job, self.file_cacher)


### PR DESCRIPTION
Resolves #6, but retain compatibility with other scoring method