### PR TITLE
Show only tc with lowest score if subtask is not solved in restricted feedback mode

### DIFF
--- a/cms/grading/scoretypes/abc.py
+++ b/cms/grading/scoretypes/abc.py
@@ -32,6 +32,7 @@ task.
 
 import logging
 import re
+import sys
 from abc import ABCMeta, abstractmethod
 
 from cms import FEEDBACK_LEVEL_RESTRICTED
@@ -289,17 +290,6 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     </td>
             {% endif %}
                 </tr>
-        {% else %}
-                <tr class="undefined">
-                    <td class="idx">{{ loop.index }}</td>
-            {% if feedback_level == FEEDBACK_LEVEL_FULL %}
-                    <td colspan="4">
-            {% else %}
-                    <td colspan="2">
-            {% endif %}
-                        {% trans %}N/A{% endtrans %}
-                    </td>
-                </tr>
         {% endif %}
     {% endfor %}
             </tbody>
@@ -392,10 +382,15 @@ class ScoreTypeGroup(ScoreTypeAlone):
 
             testcases = []
             public_testcases = []
-            previous_tc_all_correct = True
+
+            restricted_feedback_idx = None
+            restricted_feedback_outcome = sys.float_info.max
+
             for tc_idx in target:
+                outcome = float(evaluations[tc_idx].outcome)
+
                 tc_outcome = self.get_public_outcome(
-                    float(evaluations[tc_idx].outcome), parameter)
+                    outcome, parameter)
 
                 testcases.append({
                     "idx": tc_idx,
@@ -403,14 +398,13 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     "text": evaluations[tc_idx].text,
                     "time": evaluations[tc_idx].execution_time,
                     "memory": evaluations[tc_idx].execution_memory,
-                    "show_in_restricted_feedback": previous_tc_all_correct})
+                    "show_in_restricted_feedback": True})
                 if self.public_testcases[tc_idx]:
                     public_testcases.append(testcases[-1])
-                    # Only block restricted feedback if this is the first
-                    # *public* non-correct testcase, otherwise we might be
-                    # leaking info on private testcases.
-                    if tc_outcome != "Correct":
-                        previous_tc_all_correct = False
+                    
+                    if outcome < restricted_feedback_outcome:
+                        restricted_feedback_outcome = outcome
+                        restricted_feedback_idx = tc_idx
                 else:
                     public_testcases.append({"idx": tc_idx})
 
@@ -418,6 +412,10 @@ class ScoreTypeGroup(ScoreTypeAlone):
                 [float(evaluations[tc_idx].outcome) for tc_idx in target],
                 parameter)
             st_score = st_score_fraction * parameter[0]
+
+            if st_score_fraction < 1.0:
+                for t in testcases:
+                    t["show_in_restricted_feedback"] = (t["idx"] == restricted_feedback_idx)
 
             score += st_score
             subtasks.append({

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupMinTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupMinTest.py
@@ -34,6 +34,7 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
             "0_0": True,
             "1_0": True,
             "1_1": True,
+            "1_2": True,
             "2_0": True,
             "2_1": False,
             "3_0": False,
@@ -111,7 +112,7 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_number(self):
         """Test max score is correct when groups are number-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[0, 1], [s1, 2], [s2, 2], [s3, 2]]
+        parameters = [[0, 1], [s1, 3], [s2, 2], [s3, 2]]
         header = ["Subtask 0 (0)",
                   "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
@@ -142,10 +143,18 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
         self.assertComputeScore(
             gmin.compute_score(sr),
             s1 + s2 + s3, s1, [0, s1, s2, s3], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+                {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]}
             ])
 
         # Some non-public subtask is incorrect.
@@ -153,35 +162,59 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
         self.assertComputeScore(
             gmin.compute_score(sr),
             s1 + s2, s1, [0, s1, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+               {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
         # Also the public subtask is incorrect.
-        self.set_outcome(sr, "1_0", 0.0)
         self.set_outcome(sr, "1_1", 0.0)
+        self.set_outcome(sr, "1_2", 0.0)
         sr.evaluations[1].outcome = 0.0
         self.assertComputeScore(
             gmin.compute_score(sr),
             s2, 0.0, [0, 0, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+               {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": False}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
         # Some partial results.
-        self.set_outcome(sr, "3_0", 0.5)
-        self.set_outcome(sr, "3_1", 0.1)
+        self.set_outcome(sr, "1_1", 0.5)
+        self.set_outcome(sr, "1_2", 0.1)
         self.assertComputeScore(
             gmin.compute_score(sr),
-            s2 + s3 * 0.1, 0.0, [0, 0, s2, s3 * 0.1], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+            s1 * 0.1 + s2, s1 * 0.1, [0, s1 * 0.1, s2, 0], [
+               {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
 

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupMulTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupMulTest.py
@@ -34,6 +34,7 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
             "0_0": True,
             "1_0": True,
             "1_1": True,
+            "1_2": True,
             "2_0": True,
             "2_1": False,
             "3_0": False,
@@ -111,7 +112,7 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_number(self):
         """Test max score is correct when groups are number-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[0, 1], [s1, 2], [s2, 2], [s3, 2]]
+        parameters = [[0, 1], [s1, 3], [s2, 2], [s3, 2]]
         header = ["Subtask 0 (0)",
                   "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
@@ -142,10 +143,18 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
         self.assertComputeScore(
             gmul.compute_score(sr),
             s1 + s2 + s3, s1, [0, s1, s2, s3], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+                {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]}
             ])
 
         # Some non-public subtask is incorrect.
@@ -153,35 +162,59 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
         self.assertComputeScore(
             gmul.compute_score(sr),
             s1 + s2, s1, [0, s1, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+                {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
         # Also the public subtask is incorrect.
-        self.set_outcome(sr, "1_0", 0.0)
         self.set_outcome(sr, "1_1", 0.0)
+        self.set_outcome(sr, "1_2", 0.0)
         self.assertComputeScore(
             gmul.compute_score(sr),
             s2, 0.0, [0, 0, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+                {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": False}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
         # Some partial results.
-        self.set_outcome(sr, "3_0", 0.5)
-        self.set_outcome(sr, "3_1", 0.1)
+        self.set_outcome(sr, "1_1", 0.5)
+        self.set_outcome(sr, "1_2", 0.2)
         self.assertComputeScore(
             gmul.compute_score(sr),
-            s2 + s3 * 0.5 * 0.1, 0.0,
-            [0, 0, s2, s3 * 0.5 * 0.1], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+            s1 * 0.5 * 0.2 + s2, s1 * 0.5 * 0.2,
+            [0, s1 * 0.5 * 0.2, s2, 0], [
+                {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
 

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupThresholdTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupThresholdTest.py
@@ -34,6 +34,7 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
             "0_0": True,
             "1_0": True,
             "1_1": True,
+            "1_2": True,
             "2_0": True,
             "2_1": False,
             "3_0": False,
@@ -122,7 +123,7 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_number(self):
         """Test max score is correct when groups are number-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[0, 1, 0], [s1, 2, 10], [s2, 2, 20], [s3, 2, 30]]
+        parameters = [[0, 1, 0], [s1, 3, 10], [s2, 2, 20], [s3, 2, 30]]
         header = ["Subtask 0 (0)",
                   "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
@@ -159,10 +160,18 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
         self.assertComputeScore(
             st.compute_score(sr),
             s1 + s2 + s3, s1, [0, s1, s2, s3], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+                {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]}
             ])
 
         # Some non-public subtask is incorrect.
@@ -170,35 +179,59 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
         self.assertComputeScore(
             st.compute_score(sr),
             s1 + s2, s1, [0, s1, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+               {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
         # Also the public subtask is incorrect.
-        self.set_outcome(sr, "1_0", 12.5)
         self.set_outcome(sr, "1_1", 12.5)
+        self.set_outcome(sr, "1_2", 12.5)
         self.assertComputeScore(
             st.compute_score(sr),
             s2, 0.0, [0, 0, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+               {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
         # Outcome equal to 0 is special and treated as error even if it is
         # below the threshold.
-        self.set_outcome(sr, "1_0", 0.0)
         self.set_outcome(sr, "1_1", 0.0)
+        self.set_outcome(sr, "1_2", 0.0)
         self.assertComputeScore(
             st.compute_score(sr),
             s2, 0.0, [0, 0, s2, 0], [
-                {"idx": 0},
-                {"idx": 1},
-                {"idx": 2},
-                {"idx": 3}
+               {"idx": 0, "testcases": [
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 1, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": False}]},
+                {"idx": 2, "testcases": [
+                    {"show_in_restricted_feedback": True},
+                    {"show_in_restricted_feedback": True}]},
+                {"idx": 3, "testcases": [
+                    {"show_in_restricted_feedback": False},
+                    {"show_in_restricted_feedback": False}]}
             ])
 
 

--- a/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
@@ -27,7 +27,15 @@ class ScoreTypeTestMixin:
     def assertComputeScore(self, scores, total, public, rws_scores, subtasks):
         self.assertAlmostEqual(scores[0], total)
         self.assertEqual([{"idx": s["idx"]} for s in scores[1]],
-                         subtasks)
+                         [{"idx": s["idx"]} for s in subtasks])
+        self.assertEqual(
+            [
+                [
+                    {"show_in_restricted_feedback":
+                        t["show_in_restricted_feedback"]}
+                    for t in s["testcases"]]
+                for s in scores[1] if "testcases" in s],
+            [s["testcases"] for s in subtasks if "testcases" in s])
         self.assertAlmostEqual(scores[2], public)
         self.assertEqual(scores[4], [str(score) for score in rws_scores])
 


### PR DESCRIPTION
This is to implement the following rule: https://ioi2021.sg/rules/#feedback, second paragraph:

> For every submission, the grading system reports the score for each subtask. If a subtask is not fully solved, the grading system gives a feedback only for the first test case among the lowest scored test cases in the subtask.

(Apparently CMS did not support the above rule for several years without anyone noticing)