### PR TITLE
Make oom-heap.c test work with newer GCC

### DIFF
--- a/cmstestsuite/code/oom-heap.c
+++ b/cmstestsuite/code/oom-heap.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
+#include <stdlib.h>
+
+int *big;
 
 int main() {
-    int *big;
     int i;
     big = malloc(128 * 1024 * 1024);
     // If we don't do this cycle, the compiler is smart enough not to


### PR DESCRIPTION
This pull request fixes the *oom-heap (C11 / gcc)* test.

New GCC versions can optimize the old version of the test to use practically zero memory.